### PR TITLE
feat: llms.txtの拡充とsitemap.xmlの追加

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -73,8 +73,16 @@ const nextConfig = {
         destination: '/api/llms/index.txt',
       },
       {
+        source: '/llms-full.txt',
+        destination: '/api/llms/full.txt',
+      },
+      {
         source: '/llms/:path*', // :path* で任意のパスをキャプチャ
         destination: '/api/llms/:path*', // キャプチャしたパスをdestinationで利用
+      },
+      {
+        source: '/sitemap.xml',
+        destination: '/api/sitemap.xml',
       },
     ];
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,29 @@
 User-agent: *
 Allow: /
+
+# LLM crawlers (明示的に許可)
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://cti1650-portfolio-site.vercel.app/sitemap.xml

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,24 @@ const TailwindApp = ({ Component, pageProps }: AppProps) => {
       <Head>
         <title>cti1650 Portfolio</title>
         <link rel="icon" href="img/logo_icon_white.png" />
+        <link
+          rel="alternate"
+          type="text/plain"
+          title="llms.txt"
+          href="/llms.txt"
+        />
+        <link
+          rel="alternate"
+          type="text/plain"
+          title="llms-full.txt"
+          href="/llms-full.txt"
+        />
+        <link
+          rel="sitemap"
+          type="application/xml"
+          title="Sitemap"
+          href="/sitemap.xml"
+        />
         {/* <meta name="robots" content="noindex" />
         <meta name="robots" content="nofollow" /> */}
         <meta

--- a/src/pages/api/llms/full.txt.ts
+++ b/src/pages/api/llms/full.txt.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const protocol = req.headers['x-forwarded-proto'] || 'http';
+  const host = req.headers.host;
+  const baseUrl = `${protocol}://${host}`;
+
+  try {
+    const [indexRes, portfoliosRes, contentsRes] = await Promise.all([
+      fetch(`${baseUrl}/api/llms/index.txt`).then((r) => r.text()),
+      fetch(`${baseUrl}/api/llms/portfolios.txt`).then((r) => r.text()),
+      fetch(`${baseUrl}/api/llms/contents.txt`).then((r) => r.text()),
+    ]);
+
+    const content = `${indexRes}
+
+# ポートフォリオ一覧
+${portfoliosRes}
+
+# 記事一覧
+${contentsRes}`;
+
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.setHeader('Content-Length', Buffer.byteLength(content, 'utf8'));
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=3600, stale-while-revalidate=60',
+    );
+    res.status(200).send(content);
+  } catch (e) {
+    console.error('llms-full.txt の生成失敗:', e);
+    res.status(500).send('全文の取得中にエラーが発生しました。');
+  }
+}

--- a/src/pages/api/llms/index.txt.ts
+++ b/src/pages/api/llms/index.txt.ts
@@ -8,12 +8,33 @@ export default async function handler(
   const protocol = req.headers['x-forwarded-proto'] || 'http';
   const host = req.headers.host;
   const baseUrl = `${protocol}://${host}`;
-  const content = `# このサイトについて
-このサイトは、私のポートフォリオを紹介するためのものです。以下に、私のスキルセットやプロジェクトについての情報を記載しています。
+  const lastUpdated = new Date().toLocaleDateString('sv-SE', {
+    timeZone: 'Asia/Tokyo',
+  });
+  const content = `# cti1650 Portfolio
 
-# 参照先
-- [ポートフォリオ一覧](${baseUrl}/llms/portfolios.txt)
-- [記事一覧](${baseUrl}/llms/contents.txt)`;
+> Yuichi Sakagami (cti1650) のポートフォリオサイト。個人開発したChrome拡張機能・Webアプリ・ツール類と、Qiita/Zennで公開している技術記事をまとめています。
+
+Last-Updated: ${lastUpdated}
+
+## プロフィール
+- Name: Yuichi Sakagami
+- Handle: cti1650
+- Birthday: 1992-01-25
+- Skillset: HTML, JavaScript, TypeScript, CSS, React.js, Next.js, Tailwind CSS, React Native, Expo, Python, PHP, VBA, GAS, Chrome拡張機能開発
+- Qualifications & Tools: ITパスポート, VBA Expert Standard(Excel), GitHub, VSCode
+
+## リンク
+- [Site](${baseUrl}/): ポートフォリオサイト本体
+- [GitHub](https://github.com/cti1650)
+- [X (Twitter)](https://x.com/cti1650)
+- [Qiita](https://qiita.com/cti1650)
+- [Zenn](https://zenn.dev/cti1650)
+
+## 参照先
+- [ポートフォリオ一覧](${baseUrl}/llms/portfolios.txt): 公開中の個人開発プロジェクト一覧(技術スタック・リンク付き)
+- [記事一覧](${baseUrl}/llms/contents.txt): Qiita/Zennで公開している技術記事一覧(公開日・いいね数付き)
+- [全文まとめ](${baseUrl}/llms-full.txt): 上記すべてを1ファイルに連結したもの`;
   res.setHeader('Content-Length', Buffer.byteLength(content, 'utf8'));
   res.setHeader(
     'Cache-Control',

--- a/src/pages/api/sitemap.xml.ts
+++ b/src/pages/api/sitemap.xml.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const STATIC_PATHS = [
+  '/',
+  '/content',
+  '/contact',
+  '/site',
+  '/privacy_policy',
+  '/terms_of_service',
+];
+
+const LLMS_PATHS = [
+  '/llms.txt',
+  '/llms-full.txt',
+  '/llms/portfolios.txt',
+  '/llms/contents.txt',
+];
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const protocol = req.headers['x-forwarded-proto'] || 'http';
+  const host = req.headers.host;
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`;
+  const lastmod = new Date().toISOString();
+
+  const urls = [...STATIC_PATHS, ...LLMS_PATHS]
+    .map((path) => {
+      const priority = path === '/' ? '1.0' : '0.7';
+      return `  <url>
+    <loc>${baseUrl}${path}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>${priority}</priority>
+  </url>`;
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+  res.setHeader(
+    'Cache-Control',
+    'public, max-age=3600, stale-while-revalidate=60',
+  );
+  res.status(200).send(xml);
+}

--- a/src/pages/api/sitemap.xml.ts
+++ b/src/pages/api/sitemap.xml.ts
@@ -19,8 +19,7 @@ const LLMS_PATHS = [
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const protocol = req.headers['x-forwarded-proto'] || 'http';
   const host = req.headers.host;
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`;
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || `${protocol}://${host}`;
   const lastmod = new Date().toISOString();
 
   const urls = [...STATIC_PATHS, ...LLMS_PATHS]


### PR DESCRIPTION
## Summary
- LLMクローラーからのサイト理解を強化するため `llms.txt` を公式仕様に近い構成へ刷新し、プロフィール・SNSリンク・Last-Updatedを追加
- 1リクエストで全体を取得できる `llms-full.txt`(全文版)を新規提供
- `sitemap.xml` を動的生成で提供(静的ページ6本 + llms系4ファイルを対象、ポートフォリオ/記事の個別URLは意図的に除外)
- `robots.txt` に Sitemap 参照と主要LLMクローラー(GPTBot/ClaudeBot/PerplexityBot/Google-Extended等)の明示的な Allow を追加
- `_app.tsx` に `<link rel="alternate">` と `<link rel="sitemap">` を追加しHTMLからの発見性を向上

## Changes
- `src/pages/api/llms/index.txt.ts`: プロフィール/リンク/Last-Updatedを追加しllms.txt仕様準拠の構成へ
- `src/pages/api/llms/full.txt.ts` (新規): index + portfolios + contents を連結した全文版
- `src/pages/api/sitemap.xml.ts` (新規): 静的ページとllms系ファイルをXMLで列挙
- `next.config.js`: `/llms-full.txt` と `/sitemap.xml` のrewriteを追加
- `public/robots.txt`: Sitemap行と主要LLMクローラー9種の明示Allowを追加
- `src/pages/_app.tsx`: alternate/sitemap link をHeadに追加

## Test plan
- [ ] `yarn dev` 起動後、以下のURLが期待通り返ることを確認
  - [ ] `/llms.txt` — プロフィール情報とLast-Updated(JST)が含まれる
  - [ ] `/llms-full.txt` — index + portfolios + contents が連結されている
  - [ ] `/sitemap.xml` — 静的6ページ + llms系4ファイルがXMLで返る
  - [ ] `/robots.txt` — Sitemap行とLLMクローラー許可が反映されている
- [ ] トップページの `<head>` に alternate/sitemap link が出力されていることをview-sourceで確認
- [ ] Vercelへのデプロイ後、本番URLでも同様に確認

## Notes
- ポートフォリオ/記事の個別URLはsitemapに意図的に含めていません(動的ページは `noindex,nofollow` 運用のため)
- `robots.txt` の Sitemap URL は本番URL固定です。カスタムドメインに変更する場合は要更新
- \`sitemap.xml\` は \`NEXT_PUBLIC_SITE_URL\` があればそれを優先、なければリクエストホストにフォールバック

---
Generated with [Claude Code](https://claude.com/claude-code)